### PR TITLE
CORs urls are now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ The configuration file is a YAML file that contains the following properties. Ex
   - **Required**
   - A secret that will be used to sign the x-mte-client-id header. A 32+ character string is recommended.
 - `corsOrigins`
-  - **Required**
-  - A list of URLs that will be allowed to make cross-origin requests to the server.
+  - A list of URLs that will be allowed to make cross-origin requests to the server. Required by browsers to communicate with this server.
 - `port`
   - The port that the server will listen on.
   - Default: `8080`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mte-relay-server",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "",
   "scripts": {
     "start": "node --trace-warnings dist/index.js --log-adapter ../examples/log-adapters/stdout.js",

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -27,9 +27,9 @@ const settingsSchema = z.object({
   licenseCompany: z.string(),
   licenseKey: z.string(),
   clientIdSecret: z.string(),
-  corsOrigins: z.array(
-    z.string().url({ message: "corsOrigin must be a valid URL." })
-  ),
+  corsOrigins: z
+    .array(z.string().url({ message: "corsOrigin must be a valid URL." }))
+    .optional(),
   port: z.number().optional(),
   debug: z.boolean().optional(),
   passThroughRoutes: z.array(z.string()).optional(),
@@ -74,7 +74,7 @@ export default async function () {
     UPSTREAM: userSettings.upstream,
     LICENSE_COMPANY: userSettings.licenseCompany,
     LICENSE_KEY: userSettings.licenseKey,
-    CORS_ORIGINS: userSettings.corsOrigins,
+    CORS_ORIGINS: userSettings.corsOrigins || [],
     CLIENT_ID_SECRET: userSettings.clientIdSecret,
     DEBUG: userSettings.debug || DEFAULT_OPTIONS.DEBUG,
     OUTBOUND_TOKEN: userSettings.outboundToken,


### PR DESCRIPTION
CORs urls are now optional. This is only a browser requirement, but not a requirement of server-to-server communication, or even iOS or Android communication.